### PR TITLE
Make sure locale doesn't change after flush is called

### DIFF
--- a/Adapter/PhpcrOdmAdapter.php
+++ b/Adapter/PhpcrOdmAdapter.php
@@ -71,9 +71,8 @@ class PhpcrOdmAdapter implements AdapterInterface
     public function translateObject($contentDocument, $locale)
     {
         $meta = $this->dm->getMetadataFactory()->getMetadataFor(get_class($contentDocument));
-        $contentDocument = $this->dm->findTranslation($meta->getName(), $meta->getIdentifierValue($contentDocument), $locale);
 
-        return $contentDocument;
+        return $this->dm->findTranslation($meta->getName(), $meta->getIdentifierValue($contentDocument), $locale);
     }
 
     /**

--- a/Doctrine/Phpcr/AutoRouteListener.php
+++ b/Doctrine/Phpcr/AutoRouteListener.php
@@ -63,6 +63,7 @@ class AutoRouteListener
         $autoRoute = null;
         foreach ($updates as $document) {
             if ($this->isAutoRouteable($document)) {
+                $locale = $uow->getCurrentLocale($document);
 
                 $uriContextCollection = new UriContextCollection($document);
                 $arm->buildUriContextCollection($uriContextCollection);
@@ -72,6 +73,11 @@ class AutoRouteListener
                     $autoRoute = $uriContext->getAutoRoute();
                     $dm->persist($autoRoute);
                     $uow->computeChangeSets();
+                }
+
+                // reset locale to the original locale
+                if (null !== $locale) {
+                    $dm->findTranslation(get_class($document), $uow->getDocumentId($document), $locale);
                 }
             }
         }

--- a/Tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/Tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -10,7 +10,7 @@
  */
 
 
-namespace Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Functional\Subscriber;
+namespace Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Functional\EventListener;
 
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Functional\BaseTestCase;
 use Symfony\Cmf\Bundle\RoutingAutoBundle\Tests\Resources\Document\Blog;
@@ -229,7 +229,6 @@ class AutoRouteListenerTest extends BaseTestCase
         $this->getDm()->flush();
         $this->getDm()->clear();
 
-        $articleTitles = array_values($data);
         $locales = array_keys($data);
 
         foreach ($expectedPaths as $i => $expectedPath) {
@@ -269,6 +268,27 @@ class AutoRouteListenerTest extends BaseTestCase
                 ),
             ),
         );
+    }
+
+    public function testMultilangArticleRemainsSameLocale()
+    {
+        $article = new Article;
+        $article->path = '/test/article-1';
+        $this->getDm()->persist($article);
+
+        $article->title = 'Hello everybody!';
+        $this->getDm()->bindTranslation($article, 'en');
+
+        $article->title = 'Bonjour le monde!';
+        $this->getDm()->bindTranslation($article, 'fr');
+
+        // let current article be something else than the last bound locale
+        $this->getDm()->findTranslation(get_class($article), $this->getDm()->getUnitOfWork()->getDocumentId($article), 'en');
+
+        $this->getDm()->flush();
+        $this->getDm()->clear();
+
+        $this->assertEquals('Hello everybody!', $article->title);
     }
 
     /**

--- a/Tests/Resources/Document/Post.php
+++ b/Tests/Resources/Document/Post.php
@@ -40,7 +40,7 @@ class Post
     public $blog;
 
     /**
-     * @PHPCR\NodeName()
+     * @PHPCR\Nodename()
      */
     public $name;
 


### PR DESCRIPTION
Fixes #145

I could not find an easy way to test this...