### PR TITLE
Convert non-managed intermediate nodes into AutoRoute documents

### DIFF
--- a/Adapter/PhpcrOdmAdapter.php
+++ b/Adapter/PhpcrOdmAdapter.php
@@ -132,7 +132,7 @@ class PhpcrOdmAdapter implements AdapterInterface
 
             if (null === $document) {
                 $document = new Generic();
-                $document->setParent($parentDocument);
+                $document->setParentDocument($parentDocument);
                 $document->setNodeName($segment);
                 $this->dm->persist($document);
             }
@@ -165,7 +165,7 @@ class PhpcrOdmAdapter implements AdapterInterface
         $headRoute = new $this->autoRouteFqcn();
         $headRoute->setContent($contentDocument);
         $headRoute->setName($headName);
-        $headRoute->setParent($document);
+        $headRoute->setParentDocument($document);
         $headRoute->setAutoRouteTag($autoRouteTag);
         $headRoute->setType(AutoRouteInterface::TYPE_PRIMARY);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+1.0.2
+----------
+
+* Convert non-managed intermediate nodes into AutoRoute documents #165
+
+1.0.0
+-----
+
+* Enabled new `container` token provider - retrieve URL elements
+  from container parameters.
+
 1.0.0-RC1
 ---------
 

--- a/Tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/Tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -521,4 +521,37 @@ class AutoRouteListenerTest extends BaseTestCase
         $this->getDm()->persist($blog);
         $this->getDm()->flush();
     }
+
+    public function testGenericNodeShouldBeConvertedInAnAutoRouteNode()
+    {
+        $blog = new Blog;
+        $blog->path = '/test/my-post';
+        $blog->title = 'My Post';
+        $this->getDm()->persist($blog);
+        $this->getDm()->flush();
+
+        $this->assertInstanceOf(
+            'Doctrine\ODM\PHPCR\Document\Generic',
+            $this->getDm()->find(null, '/test/auto-route/blog')
+        );
+        $blogRoute = $this->getDm()->find(null, '/test/auto-route/blog/my-post');
+        $this->assertInstanceOf('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface', $blogRoute);
+        $this->assertSame($blog, $blogRoute->getContent());
+
+        $page = new Page;
+        $page->path = '/test/blog';
+        $page->title = 'Blog';
+
+        $this->getDm()->persist($page);
+        $this->getDm()->flush();
+
+        $this->assertInstanceOf(
+            'Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface',
+            $this->getDm()->find(null, '/test/auto-route/blog')
+        );
+        $this->assertInstanceOf(
+            'Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface',
+            $this->getDm()->find(null, '/test/auto-route/blog/my-post')
+        );
+    }
 }

--- a/Tests/Unit/Adapter/PhpcrOdmAdapterTest.php
+++ b/Tests/Unit/Adapter/PhpcrOdmAdapterTest.php
@@ -121,7 +121,7 @@ class PhpcrOdmAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute', $res);
         $this->assertEquals($expectedName, $res->getName());
 
-        $this->assertSame($this->parentRoute, $res->getParent());
+        $this->assertSame($this->parentRoute, $res->getParentDocument());
         $this->assertSame($this->contentDocument, $res->getContent());
     }
 


### PR DESCRIPTION
This is a backport on 1.0 branch of the feature/bugfix for the
Generic intermediates nodes which now will be converted in
AutoRoute if needed.